### PR TITLE
Fixed an import error for Iterable

### DIFF
--- a/specio/core/format.py
+++ b/specio/core/format.py
@@ -7,7 +7,7 @@
 from __future__ import print_function
 
 import os
-from collections import Iterable
+from collections.abc import Iterable
 from warnings import warn
 from six import string_types
 


### PR DESCRIPTION
Small change required by the [move of `Iterable` into `collections.abc`](https://docs.python.org/3/library/collections.abc.html#collections.abc.Iterable)